### PR TITLE
cleanup range interface

### DIFF
--- a/source/kafkad/consumer.d
+++ b/source/kafkad/consumer.d
@@ -71,42 +71,35 @@ class Consumer : IWorker {
             inflateEnd(&m_zlibContext);
 
         client.addNewConsumer(this);
+        popFront(); // seed message
     }
 
     private void swapBuffers(bool isDecompressedBuffer) {
         swap(m_currentBuffer, m_compressionBuffer);
         m_isDecompressedBuffer = isDecompressedBuffer;
     }
-    
+
     Message front()
     {
         return m_message;
     }
-    
+
     void popFront()
     {
-        m_message = getMessage();
-    }
-    
-    bool empty()
-    { 
-        return false;
+        m_message = fetchMessage();
     }
 
-    int opApply(int delegate( Message) dg)
-    {
-       int result;
-       for(;;)
-       {
-         popFront();
-         if (dg(front())) 
-            return result;         
-       }
-       assert(0);
-    }
-    
+    enum empty = false;
+
     // TODO: make private
     Message getMessage() {
+        auto m = front;
+        popFront;
+        return m;
+    }
+
+private:
+    Message fetchMessage() {
         if (!m_currentBuffer) {
             synchronized (m_queue.mutex) {
                 m_currentBuffer = m_queue.waitForBuffer(BufferType.Filled);


### PR DESCRIPTION
- make sure there is a message before front get's called
- remove opApply, foreach can use front/popFront/empty
  (avoids callback overhead and closure allocation)
- use enum false for infinite range