### PR TITLE
Replaced vibe.d dependency with vibe-core

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
     "authors": ["Piotr Szturmaj", "Yannick Koechlin"],
     "license" : "MIT",
     "dependencies": {
-        "vibe-d": ">=0.8.4"
+        "vibe-core": "~>1.4.1"
     },
     "libs": ["snappy"],
     "targetType": "library"


### PR DESCRIPTION
kafka-d is only using parts from vibe.core which is in the meantime a separate dub package.
Directly using vibe.core has major compilation time benefits as the dependency tree is much smaller.